### PR TITLE
Cancel subscription ep

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -8,6 +8,7 @@ class Api::V1::SubscriptionsController < ApplicationController
   def update
     active_sub = CustomerSubscription.find(params[:cust_sub])
     active_sub.update!(status: 1)
+    render json: CustomerSubscriptionSerializer.update_sub(active_sub)
   end
 
   private

--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -5,6 +5,11 @@ class Api::V1::SubscriptionsController < ApplicationController
     render json: CustomerSubscriptionSerializer.new_sub(cust_sub)
   end
 
+  def update
+    active_sub = CustomerSubscription.find(params[:cust_sub])
+    active_sub.update!(status: 1)
+  end
+
   private
   def sub_params
     params.permit(:customer_id, :subscription_id)

--- a/app/models/customer_subscription.rb
+++ b/app/models/customer_subscription.rb
@@ -18,4 +18,8 @@ class CustomerSubscription < ApplicationRecord
   def cost
     subscription.price.to_f / 100.0
   end
+
+  def sub_title
+    subscription.title
+  end
 end

--- a/app/serializers/customer_subscription_serializer.rb
+++ b/app/serializers/customer_subscription_serializer.rb
@@ -11,4 +11,16 @@ class CustomerSubscriptionSerializer
       }
     }
   end
+
+  def self.update_sub(cust_sub)
+    {
+      data: {
+        customer: "#{cust_sub.customer.first_name} #{cust_sub.customer.last_name}",
+        tea: cust_sub.tea_name,
+        frequency: cust_sub.sub_frequency,
+        cost: cust_sub.cost,
+        status: cust_sub.status
+      }
+    }
+  end
 end

--- a/app/serializers/customer_subscription_serializer.rb
+++ b/app/serializers/customer_subscription_serializer.rb
@@ -17,8 +17,8 @@ class CustomerSubscriptionSerializer
       data: {
         customer: "#{cust_sub.customer.first_name} #{cust_sub.customer.last_name}",
         tea: cust_sub.tea_name,
+        subscription: cust_sub.sub_title,
         frequency: cust_sub.sub_frequency,
-        cost: cust_sub.cost,
         status: cust_sub.status
       }
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
  namespace :api do
    namespace :v1 do
      post "/subscriptions", to: 'subscriptions#create'
+     put "/subscriptions", to: 'subscriptions#update'
    end
  end
 end

--- a/spec/models/customer_subscriptions_spec.rb
+++ b/spec/models/customer_subscriptions_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe CustomerSubscription, type: :model do
       expect(cust_sub.tea_name).to eq("White Jade")
       expect(cust_sub.sub_frequency).to eq("weekly")
       expect(cust_sub.cost).to eq(14.99)
+      expect(cust_sub.sub_title).to eq("White Tea Addict")
       expect(cust_sub.status).to eq("active") #not an instance method, checking default
     end
   end

--- a/spec/requests/api/v1/cancel_subscription_spec.rb
+++ b/spec/requests/api/v1/cancel_subscription_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe 'Subscription cancelation endpoint' do
 
     @sub1 = Subscription.create!(title: "White Tea Addict", frequency: 0, price: 1499, tea_id: tea1.id )
     @sub2 = Subscription.create!(title: "Grey Connoisseur", frequency: 1, price: 2499, tea_id: tea2.id)
+    @active_sub = CustomerSubscription.create!({ customer_id: @customer1.id, subscription_id: @sub2.id })
   end
 
   it 'can get a successful response, and change the status of a CustSub' do
     headers = { "CONTENT_TYPE" => "application/json" }
-    active_sub = CustomerSubscription.create!({ customer_id: @customer1.id, subscription_id: @sub1.id })
-    cancel_params = { cust_sub: active_sub.id }
+    cancel_params = { cust_sub: @active_sub.id }
 
     put "/api/v1/subscriptions", headers: headers, params: JSON.generate(cancel_params)
     expect(response).to be_successful
@@ -23,5 +23,29 @@ RSpec.describe 'Subscription cancelation endpoint' do
 
     expect(canceled_sub.length).to eq(1)
     expect(canceled_sub.first.status).to eq("canceled")
+  end
+
+  it 'can return information about the user and their updated subscription' do
+    headers = { "CONTENT_TYPE" => "application/json" }
+    cancel_params = { cust_sub: @active_sub.id }
+
+    put "/api/v1/subscriptions", headers: headers, params: JSON.generate(cancel_params)
+
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    cancel_sub_return = response_body[:data]
+
+    expect(cancel_sub_return).to be_a(Hash)
+    expect(cancel_sub_return.keys).to eq([:customer, :tea, :frequency, :cost, :status])
+    expect(cancel_sub_return[:customer]).to be_a(String)
+    expect(cancel_sub_return[:tea]).to be_a(String)
+    expect(cancel_sub_return[:frequency]).to be_a(String)
+    expect(cancel_sub_return[:cost]).to be_a(Float)
+    expect(cancel_sub_return[:status]).to be_a(String)
+
+    expect(cancel_sub_return[:customer]).to eq("Jimbob Dudeguy")
+    expect(cancel_sub_return[:tea]).to eq("Lady Grey")
+    expect(cancel_sub_return[:frequency]).to eq("monthly")
+    expect(cancel_sub_return[:cost]).to eq(24.99)
+    expect(cancel_sub_return[:status]).to eq("canceled")
   end
 end

--- a/spec/requests/api/v1/cancel_subscription_spec.rb
+++ b/spec/requests/api/v1/cancel_subscription_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Subscription cancelation endpoint' do
+  before(:each) do
+    @customer1 = Customer.create!(first_name: "Jimbob", last_name: "Dudeguy", email: "ItsJim@TheDude.org", address: "555 Living st, Location FL, 33590")
+    @customer2 = Customer.create!(first_name: "Ivanna", last_name: "Pepsi", email: "justone@pepsi.pls", address: "789 Cola lane, Carbonation FL, 33585")
+
+    tea1 = Tea.create!(title: "White Jade", description: "A light, slightly fruity white tea.", brew_time: 3, temperature: 195.6)
+    tea2 = Tea.create!(title: "Lady Grey", description: "All the benefits of Earl Grey, with a little citrus.", brew_time: 7, temperature: 200.0)
+
+    @sub1 = Subscription.create!(title: "White Tea Addict", frequency: 0, price: 1499, tea_id: tea1.id )
+    @sub2 = Subscription.create!(title: "Grey Connoisseur", frequency: 1, price: 2499, tea_id: tea2.id)
+  end
+
+  it 'can get a successful response' do
+    headers = { "CONTENT_TYPE" => "application/json" }
+    sub_params = { customer_id: @customer1.id, subscription_id: @sub1.id }
+    CustomerSubscription.create!(sub_params)
+
+    put "/api/v1/subscriptions", headers: headers, params: JSON.generate(sub_params)
+    expect(response).to be_successful
+  end
+end

--- a/spec/requests/api/v1/cancel_subscription_spec.rb
+++ b/spec/requests/api/v1/cancel_subscription_spec.rb
@@ -35,17 +35,17 @@ RSpec.describe 'Subscription cancelation endpoint' do
     cancel_sub_return = response_body[:data]
 
     expect(cancel_sub_return).to be_a(Hash)
-    expect(cancel_sub_return.keys).to eq([:customer, :tea, :frequency, :cost, :status])
+    expect(cancel_sub_return.keys).to eq([:customer, :tea, :subscription, :frequency, :status])
     expect(cancel_sub_return[:customer]).to be_a(String)
     expect(cancel_sub_return[:tea]).to be_a(String)
+    expect(cancel_sub_return[:subscription]).to be_a(String)
     expect(cancel_sub_return[:frequency]).to be_a(String)
-    expect(cancel_sub_return[:cost]).to be_a(Float)
     expect(cancel_sub_return[:status]).to be_a(String)
 
     expect(cancel_sub_return[:customer]).to eq("Jimbob Dudeguy")
     expect(cancel_sub_return[:tea]).to eq("Lady Grey")
+    expect(cancel_sub_return[:subscription]).to eq("Grey Connoisseur")
     expect(cancel_sub_return[:frequency]).to eq("monthly")
-    expect(cancel_sub_return[:cost]).to eq(24.99)
     expect(cancel_sub_return[:status]).to eq("canceled")
   end
 end

--- a/spec/requests/api/v1/cancel_subscription_spec.rb
+++ b/spec/requests/api/v1/cancel_subscription_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe 'Subscription cancelation endpoint' do
 
   it 'can get a successful response' do
     headers = { "CONTENT_TYPE" => "application/json" }
-    sub_params = { customer_id: @customer1.id, subscription_id: @sub1.id }
-    CustomerSubscription.create!(sub_params)
+    active_sub = CustomerSubscription.create!({ customer_id: @customer1.id, subscription_id: @sub1.id })
+    cancel_params = { cust_sub: active_sub.id }
 
-    put "/api/v1/subscriptions", headers: headers, params: JSON.generate(sub_params)
+    put "/api/v1/subscriptions", headers: headers, params: JSON.generate(cancel_params)
     expect(response).to be_successful
   end
 end

--- a/spec/requests/api/v1/cancel_subscription_spec.rb
+++ b/spec/requests/api/v1/cancel_subscription_spec.rb
@@ -12,12 +12,16 @@ RSpec.describe 'Subscription cancelation endpoint' do
     @sub2 = Subscription.create!(title: "Grey Connoisseur", frequency: 1, price: 2499, tea_id: tea2.id)
   end
 
-  it 'can get a successful response' do
+  it 'can get a successful response, and change the status of a CustSub' do
     headers = { "CONTENT_TYPE" => "application/json" }
     active_sub = CustomerSubscription.create!({ customer_id: @customer1.id, subscription_id: @sub1.id })
     cancel_params = { cust_sub: active_sub.id }
 
     put "/api/v1/subscriptions", headers: headers, params: JSON.generate(cancel_params)
     expect(response).to be_successful
+    canceled_sub = CustomerSubscription.all
+
+    expect(canceled_sub.length).to eq(1)
+    expect(canceled_sub.first.status).to eq("canceled")
   end
 end


### PR DESCRIPTION
Test coverage at 100%. Added endpoint to change a CustomerSubscription's status from active to canceled. (Can change to also update from canceled to active in the future) Included new serializer method, new instance method added to CustSub model. 